### PR TITLE
Add regex match for the vars tool

### DIFF
--- a/server/src/varlist.c
+++ b/server/src/varlist.c
@@ -58,6 +58,7 @@ SOFTWARE.
 #include <strings.h>
 #include <syslog.h>
 #include <ctype.h>
+#include <regex.h>
 #include <varserver/varclient.h>
 #include <varserver/varserver.h>
 #include <varserver/varobject.h>
@@ -4602,6 +4603,19 @@ static int varlist_Match( VarID *pVarID, SearchContext *ctx )
             if( searchtype & QUERY_MATCH )
             {
                 found &= (strcasestr(pVarID->name, ctx->query.match) != NULL );
+            }
+
+            /* regex matching */
+            if( searchtype & QUERY_REGEX )
+            {
+                regex_t regex;
+                regmatch_t match[1];
+
+                if( regcomp(&regex, ctx->query.match, REG_EXTENDED) == 0 )
+                {
+                    found &= (regexec(&regex, pVarID->name, 1, match, 0) == 0 );
+                    regfree(&regex);
+                }
             }
 
             /* instance ID matching */

--- a/vars/src/vars.c
+++ b/vars/src/vars.c
@@ -158,37 +158,40 @@ int main(int argC, char *argV[])
         if ( pState->hVarServer != NULL )
         {
             /* Process Options */
-            ProcessOptions( argC, argV, pState );
-
-            if ( pState->username != NULL )
+            rc = ProcessOptions( argC, argV, pState );
+            if ( rc == 0 )
             {
-                rc = SetUser( pState );
-                if ( rc == EOK )
-                {
-                    userChanged = true;
-                }
-                else
-                {
-                    fprintf( stderr,
-                            "Failed to set user to: %s rc=%d (%s)\n",
-                            pState->username,
-                            rc,
-                            strerror(rc) );
-                }
-            }
 
-            /* make the query */
-            (void)VARQUERY_Search( pState->hVarServer,
-                                   pState->searchType,
-                                   pState->searchText,
-                                   pState->tagspec,
-                                   pState->instanceID,
-                                   pState->flags,
-                                   pState->fd );
+                if ( pState->username != NULL )
+                {
+                    rc = SetUser( pState );
+                    if ( rc == EOK )
+                    {
+                        userChanged = true;
+                    }
+                    else
+                    {
+                        fprintf( stderr,
+                                "Failed to set user to: %s rc=%d (%s)\n",
+                                pState->username,
+                                rc,
+                                strerror(rc) );
+                    }
+                }
 
-            if ( userChanged == true )
-            {
-                rc = setuid( uid );
+                /* make the query */
+                (void)VARQUERY_Search( pState->hVarServer,
+                                    pState->searchType,
+                                    pState->searchText,
+                                    pState->tagspec,
+                                    pState->instanceID,
+                                    pState->flags,
+                                    pState->fd );
+
+                if ( userChanged == true )
+                {
+                    rc = setuid( uid );
+                }
             }
 
             /* close the variable server */
@@ -222,7 +225,7 @@ static void usage( char *cmdname )
         fprintf(stderr,
                 "usage: %s [-n name] [-v] [-h]\n"
                 " [-n name] : variable name search term\n"
-                " [-r regex] : variable name serach by a regular expression\n"
+                " [-r regex] : variable name search by a regular expression\n"
                 " [-f flagslist] : variable flags search term\n"
                 " [-i instanceID]: instance identifier search term\n"
                 " [-h] : display this help\n"
@@ -252,7 +255,7 @@ static void usage( char *cmdname )
         pState
             pointer to the vars state
 
-    @return none
+    @return 0 if processing was successful, 1 otherwise
 
 ==============================================================================*/
 static int ProcessOptions( int argC,
@@ -260,14 +263,12 @@ static int ProcessOptions( int argC,
                            VarsState *pState )
 {
     int c;
-    int result = EINVAL;
+    int result = EOK;
     const char *options = "hvn:r:f:i:u:t:";
 
     if( ( pState != NULL ) &&
         ( argV != NULL ) )
     {
-        result = EOK;
-
         while( ( c = getopt( argC, argV, options ) ) != -1 )
         {
             switch( c )
@@ -307,7 +308,7 @@ static int ProcessOptions( int argC,
 
                 case 'h':
                     usage( argV[0] );
-                    exit(0);
+                    result = EINVAL;
                     break;
 
                 default:

--- a/vars/src/vars.c
+++ b/vars/src/vars.c
@@ -307,6 +307,7 @@ static int ProcessOptions( int argC,
 
                 case 'h':
                     usage( argV[0] );
+                    exit(0);
                     break;
 
                 default:

--- a/vars/src/vars.c
+++ b/vars/src/vars.c
@@ -222,6 +222,7 @@ static void usage( char *cmdname )
         fprintf(stderr,
                 "usage: %s [-n name] [-v] [-h]\n"
                 " [-n name] : variable name search term\n"
+                " [-r regex] : variable name serach by a regular expression\n"
                 " [-f flagslist] : variable flags search term\n"
                 " [-i instanceID]: instance identifier search term\n"
                 " [-h] : display this help\n"
@@ -260,7 +261,7 @@ static int ProcessOptions( int argC,
 {
     int c;
     int result = EINVAL;
-    const char *options = "hvn:f:i:u:t:";
+    const char *options = "hvn:r:f:i:u:t:";
 
     if( ( pState != NULL ) &&
         ( argV != NULL ) )
@@ -283,6 +284,11 @@ static int ProcessOptions( int argC,
                 case 'n':
                     pState->searchText = optarg;
                     pState->searchType |= QUERY_MATCH;
+                    break;
+
+                case 'r':
+                    pState->searchText = optarg;
+                    pState->searchType |= QUERY_REGEX;
                     break;
 
                 case 'f':


### PR DESCRIPTION
Example use:
```
$ mkvar -t int16 ala
$ mkvar -t int16 ala/bala 
$ mkvar -t int16 ala/bala/nica
$ /vars -vr 'ala'            <- it acts line the -n option
ala/bala=0
ala/bala/nica=0
ala=0
$ vars -vr 'ala/.*/..ca'     <- but it can perform regex as well
ala/bala/nica=0
$ vars -vr 'ala/.*c[ab]'
ala/bala/nica=0
$ vars -vr 'Ala.*'           <- it is case sensitive
$
```