### PR TITLE
Negative flags query results

### DIFF
--- a/client/inc/varserver/var.h
+++ b/client/inc/varserver/var.h
@@ -104,6 +104,9 @@ typedef uint32_t VAR_HANDLE;
 /*! query output value */
 #define QUERY_SHOWVALUE ( 1 << 5 )
 
+/*! negate query results */
+#define QUERY_NEGATIVE ( 1 << 6 )
+
 /*! Variable flags */
 typedef enum _VarFlags
 {

--- a/client/inc/varserver/var.h
+++ b/client/inc/varserver/var.h
@@ -104,8 +104,8 @@ typedef uint32_t VAR_HANDLE;
 /*! query output value */
 #define QUERY_SHOWVALUE ( 1 << 5 )
 
-/*! negate query results */
-#define QUERY_NEGATIVE ( 1 << 6 )
+/*! negate query results for flags */
+#define QUERY_NEGATE_FLAGS ( 1 << 6 )
 
 /*! Variable flags */
 typedef enum _VarFlags

--- a/server/src/varlist.c
+++ b/server/src/varlist.c
@@ -4645,6 +4645,11 @@ static int varlist_Match( VarID *pVarID, SearchContext *ctx )
 
                 found &= match;
             }
+
+            if (searchtype & QUERY_NEGATIVE)
+            {
+                found = !found;
+            }
         }
 
         result = ( found == true ) ? EOK : ENOENT;

--- a/server/src/varlist.c
+++ b/server/src/varlist.c
@@ -4628,6 +4628,12 @@ static int varlist_Match( VarID *pVarID, SearchContext *ctx )
             if( searchtype & QUERY_FLAGS )
             {
                 match = (ctx->query.flags & pVarStorage->flags ) ? true : false;
+
+                if (searchtype & QUERY_NEGATE_FLAGS)
+                {
+                    match = !match;
+                }
+
                 found &= match;
             }
 
@@ -4644,11 +4650,6 @@ static int varlist_Match( VarID *pVarID, SearchContext *ctx )
                 }
 
                 found &= match;
-            }
-
-            if (searchtype & QUERY_NEGATIVE)
-            {
-                found = !found;
             }
         }
 

--- a/vars/src/vars.c
+++ b/vars/src/vars.c
@@ -227,7 +227,7 @@ static void usage( char *cmdname )
                 " [-n name] : variable name search term\n"
                 " [-r regex] : variable name search by a regular expression\n"
                 " [-f flagslist] : variable flags search term\n"
-                " [-F]: negative variable flags search. Supercedes -f\n"
+                " [-F flagslist]: negative variable flags search. Supercedes -f\n"
                 " [-i instanceID]: instance identifier search term\n"
                 " [-h] : display this help\n"
                 " [-v] : output values\n",

--- a/vars/src/vars.c
+++ b/vars/src/vars.c
@@ -227,8 +227,8 @@ static void usage( char *cmdname )
                 " [-n name] : variable name search term\n"
                 " [-r regex] : variable name search by a regular expression\n"
                 " [-f flagslist] : variable flags search term\n"
+                " [-x]: negate flags search, use with -f\n"
                 " [-i instanceID]: instance identifier search term\n"
-                " [-x]: negative search\n"
                 " [-h] : display this help\n"
                 " [-v] : output values\n",
                 cmdname );
@@ -304,7 +304,7 @@ static int ProcessOptions( int argC,
                     break;
 
                 case 'x':
-                    pState->searchType |= QUERY_NEGATIVE;
+                    pState->searchType |= QUERY_NEGATE_FLAGS;
                     break;
 
                 case 'u':

--- a/vars/src/vars.c
+++ b/vars/src/vars.c
@@ -227,7 +227,7 @@ static void usage( char *cmdname )
                 " [-n name] : variable name search term\n"
                 " [-r regex] : variable name search by a regular expression\n"
                 " [-f flagslist] : variable flags search term\n"
-                " [-x]: negate flags search, use with -f\n"
+                " [-F]: negative variable flags search. Supercedes -f\n"
                 " [-i instanceID]: instance identifier search term\n"
                 " [-h] : display this help\n"
                 " [-v] : output values\n",
@@ -265,7 +265,7 @@ static int ProcessOptions( int argC,
 {
     int c;
     int result = EOK;
-    const char *options = "hvxn:r:f:i:u:t:";
+    const char *options = "hvn:r:f:F:i:u:t:";
 
     if( ( pState != NULL ) &&
         ( argV != NULL ) )
@@ -298,13 +298,14 @@ static int ProcessOptions( int argC,
                     VARSERVER_StrToFlags( optarg, &pState->flags );
                     break;
 
+                case 'F':
+                    pState->searchType |= QUERY_FLAGS | QUERY_NEGATE_FLAGS;
+                    VARSERVER_StrToFlags( optarg, &pState->flags );
+                    break;
+
                 case 't':
                     pState->searchType |= QUERY_TAGS;
                     pState->tagspec = optarg;
-                    break;
-
-                case 'x':
-                    pState->searchType |= QUERY_NEGATE_FLAGS;
                     break;
 
                 case 'u':

--- a/vars/src/vars.c
+++ b/vars/src/vars.c
@@ -228,6 +228,7 @@ static void usage( char *cmdname )
                 " [-r regex] : variable name search by a regular expression\n"
                 " [-f flagslist] : variable flags search term\n"
                 " [-i instanceID]: instance identifier search term\n"
+                " [-x]: negative search\n"
                 " [-h] : display this help\n"
                 " [-v] : output values\n",
                 cmdname );
@@ -264,7 +265,7 @@ static int ProcessOptions( int argC,
 {
     int c;
     int result = EOK;
-    const char *options = "hvn:r:f:i:u:t:";
+    const char *options = "hvxn:r:f:i:u:t:";
 
     if( ( pState != NULL ) &&
         ( argV != NULL ) )
@@ -300,6 +301,10 @@ static int ProcessOptions( int argC,
                 case 't':
                     pState->searchType |= QUERY_TAGS;
                     pState->tagspec = optarg;
+                    break;
+
+                case 'x':
+                    pState->searchType |= QUERY_NEGATIVE;
                     break;
 
                 case 'u':


### PR DESCRIPTION
Example use:
```
shondll@shondll-X1:/work/af/sunpower/pvs6/tgp/varserver/build_pc/bin$ ./mkvar -t int16 -f volatile -n vol
shondll@shondll-X1:/work/af/sunpower/pvs6/tgp/varserver/build_pc/bin$ ./mkvar -t int16 -n nvol
shondll@shondll-X1:/work/af/sunpower/pvs6/tgp/varserver/build_pc/bin$ ./vars -n vol
vol
nvol
shondll@shondll-X1:/work/af/sunpower/pvs6/tgp/varserver/build_pc/bin$ ./vars -f volatile
vol
shondll@shondll-X1:/work/af/sunpower/pvs6/tgp/varserver/build_pc/bin$ ./vars -xf volatile
/varserver/stats/tps
/varserver/stats/transactions
/varserver/stats/blocked_clients
/varserver/client/info
/varserver/stats/close
/varserver/stats/echo
/varserver/stats/new
/varserver/stats/alias
/varserver/stats/getaliases
/varserver/stats/find
/varserver/stats/get
/varserver/stats/print
/varserver/stats/set
/varserver/stats/type
/varserver/stats/name
/varserver/stats/length
/varserver/stats/flags
/varserver/stats/info
/varserver/stats/notify
/varserver/stats/notify_cancel
/varserver/stats/validate_request
/varserver/stats/validation_response
/varserver/stats/open_print_session
/varserver/stats/close_print_session
/varserver/stats/get_first
/varserver/stats/get_next
/varserver/stats/set_flags
/varserver/stats/clear_flags
nvol
shondll@shondll-X1:/work/af/sunpower/pvs6/tgp/varserver/build_pc/bin$ ./vars -xf volatile -n vol
nvol
shondll@shondll-X1:/work/af/sunpower/pvs6/tgp/varserver/build_pc/bin$
```