### PR TITLE
Allow client reconnection to varserver

### DIFF
--- a/client/inc/varserver/varclient.h
+++ b/client/inc/varserver/varclient.h
@@ -189,6 +189,9 @@ typedef struct _varClient
     /*! time structure used to set timeouts for semaphores */
     struct timespec ts;
 
+    /*! request timeout in milliseconds */
+    uint32_t requestTimeout_ms;
+
     /*! client message queue used to receive notifications */
     mqd_t notificationQ;
 

--- a/client/inc/varserver/varclient.h
+++ b/client/inc/varserver/varclient.h
@@ -186,6 +186,9 @@ typedef struct _varClient
     /*! semaphore used to synchronize client and server */
     sem_t sem;
 
+    /*! time structure used to set timeouts for semaphores */
+    struct timespec ts;
+
     /*! client message queue used to receive notifications */
     mqd_t notificationQ;
 

--- a/client/inc/varserver/varclient.h
+++ b/client/inc/varserver/varclient.h
@@ -189,8 +189,8 @@ typedef struct _varClient
     /*! time structure used to set timeouts for semaphores */
     struct timespec ts;
 
-    /*! request timeout in milliseconds */
-    uint32_t requestTimeout_ms;
+    /*! request timeout in seconds */
+    uint32_t requestTimeout_s;
 
     /*! client message queue used to receive notifications */
     mqd_t notificationQ;

--- a/client/inc/varserver/varserver.h
+++ b/client/inc/varserver/varserver.h
@@ -243,7 +243,7 @@ int VAR_GetFromQueue( VARSERVER_HANDLE hVarServer,
                       size_t len );
 
 int VARSERVER_SetRequestTimeout( VARSERVER_HANDLE hVarServer,
-                                 uint32_t timeout_ms );
+                                 uint32_t timeout_s );
 
 int VARSERVER_Signalfd( int flags );
 

--- a/client/inc/varserver/varserver.h
+++ b/client/inc/varserver/varserver.h
@@ -242,6 +242,9 @@ int VAR_GetFromQueue( VARSERVER_HANDLE hVarServer,
                       char *buf,
                       size_t len );
 
+int VARSERVER_SetRequestTimeout( VARSERVER_HANDLE hVarServer,
+                                 uint32_t timeout_ms );
+
 int VARSERVER_Signalfd( int flags );
 
 int VARSERVER_WaitSignalfd( int fd, int32_t *sigval );

--- a/client/src/varclient.c
+++ b/client/src/varclient.c
@@ -179,17 +179,23 @@ int ClientRequest( VarClient *pVarClient, int signal )
             {
                 do
                 {
-                    result = clock_gettime(CLOCK_REALTIME, &pVarClient->ts);
-                    if( result == -1)
-                    {
-                        continue;
+                    if ( pVarClient->requestTimeout_ms > 0) {
+                        result = clock_gettime(CLOCK_REALTIME, &pVarClient->ts);
+                        if( result == -1)
+                        {
+                            continue;
+                        }
+
+                        // Add 5 second timeout
+                        pVarClient->ts.tv_sec += 5;
+
+                        pVarClient->blocked = 1;
+                        result = sem_timedwait( &pVarClient->sem, &pVarClient->ts );
+                    } else {
+                        pVarClient->blocked = 1;
+                        result = sem_wait( &pVarClient->sem );
                     }
 
-                    // Add 5 second timeout
-                    pVarClient->ts.tv_sec += 5;
-
-                    pVarClient->blocked = 1;
-                    result = sem_timedwait( &pVarClient->sem, &pVarClient->ts );
                     if( result == EOK )
                     {
                         if( pVarClient->debug >= LOG_DEBUG )

--- a/client/src/varclient.c
+++ b/client/src/varclient.c
@@ -179,19 +179,22 @@ int ClientRequest( VarClient *pVarClient, int signal )
             {
                 do
                 {
-                    if ( pVarClient->requestTimeout_ms > 0) {
+                    if ( pVarClient->requestTimeout_s > 0)
+                    {
                         result = clock_gettime(CLOCK_REALTIME, &pVarClient->ts);
                         if( result == -1)
                         {
                             continue;
                         }
 
-                        // Add 5 second timeout
-                        pVarClient->ts.tv_sec += 5;
+                        /* add the timeout to the current time */
+                        pVarClient->ts.tv_sec += pVarClient->requestTimeout_s;
 
                         pVarClient->blocked = 1;
                         result = sem_timedwait( &pVarClient->sem, &pVarClient->ts );
-                    } else {
+                    }
+                    else
+                    {
                         pVarClient->blocked = 1;
                         result = sem_wait( &pVarClient->sem );
                     }

--- a/client/src/varclient.c
+++ b/client/src/varclient.c
@@ -125,8 +125,10 @@ VarClient *ValidateHandle( VARSERVER_HANDLE hVarServer )
     The ClientRequest function is used to send a client request from a
     client to the Variable Server.
 
-    This is a blocking call.  The client will wait until explicitly
-    released by the server.  If the server dies, the client will hang!
+    This is a blocking call with a fixed timeout of 5s. The client will wait
+    until explicitly released by the server or the timeout expires. If the
+    server dies, the call will exit with a timeout error code. If other
+    syncronization erros occur, a call will be retied.
 
     @param[in]
         pVarClient

--- a/client/src/varserver.c
+++ b/client/src/varserver.c
@@ -3702,7 +3702,7 @@ static int NewClientSemaphore( VarClient *pVarClient )
         sem_init( &pVarClient->sem, 1, 0 );
 
         /* infinite timeout by default */
-        pVarClient->requestTimeout_ms = 0;
+        pVarClient->requestTimeout_s = 0;
 
         result = EOK;
     }
@@ -3870,23 +3870,23 @@ int VAR_GetFromQueue( VARSERVER_HANDLE hVarServer,
         hVarServer
             handle to the variable server
 
-    @param[out]
-        timeout_ms
-            timeout value in milliseconds to set
+    @param[in]
+        timeout_s
+            timeout value in seconds to set
 
     @retval EOK - the request timeout was successfully set
     @retval EINVAL - invalid arguments
 
 ==============================================================================*/
 int VARSERVER_SetRequestTimeout( VARSERVER_HANDLE hVarServer,
-                                 uint32_t timeout_ms )
+                                 uint32_t timeout_s )
 {
     int result = EINVAL;
     VarClient *pVarClient = ValidateHandle( hVarServer );
 
     if( pVarClient != NULL )
     {
-        pVarClient->requestTimeout_ms = timeout_ms;
+        pVarClient->requestTimeout_s = timeout_s;
         result = EOK;
     }
 

--- a/client/src/varserver.c
+++ b/client/src/varserver.c
@@ -692,23 +692,21 @@ int VARSERVER_CreateVar( VARSERVER_HANDLE hVarServer,
 int VARSERVER_Test( VARSERVER_HANDLE hVarServer )
 {
     int result = EINVAL;
-    int i;
+
     VarClient *pVarClient = ValidateHandle( hVarServer );
     if( pVarClient != NULL )
     {
-        for(i=0;i<1;i++)
+        /* use the handle as a cookie */
+        pVarClient->requestVal = (intptr_t)hVarServer;
+        pVarClient->requestType = VARREQUEST_ECHO;
+        result = ClientRequest( pVarClient, SIG_CLIENT_REQUEST );
+        if( pVarClient->debug >= LOG_DEBUG )
         {
-            pVarClient->requestVal = i;
-            pVarClient->requestType = VARREQUEST_ECHO;
-            result = ClientRequest( pVarClient, SIG_CLIENT_REQUEST );
-            if( pVarClient->debug >= LOG_DEBUG )
-            {
-                printf("Client %d sent %d and received %d, result %d\n",
-                    pVarClient->clientid,
-                    pVarClient->requestVal,
-                    pVarClient->responseVal,
-                    result);
-            }
+            printf("Client %d sent %d and received %d, result %d\n",
+                pVarClient->clientid,
+                pVarClient->requestVal,
+                pVarClient->responseVal,
+                result);
         }
     }
 

--- a/client/src/varserver.c
+++ b/client/src/varserver.c
@@ -3700,6 +3700,10 @@ static int NewClientSemaphore( VarClient *pVarClient )
     if( pVarClient != NULL )
     {
         sem_init( &pVarClient->sem, 1, 0 );
+
+        /* infinite timeout by default */
+        pVarClient->requestTimeout_ms = 0;
+
         result = EOK;
     }
 
@@ -3848,6 +3852,42 @@ int VAR_GetFromQueue( VARSERVER_HANDLE hVarServer,
         {
             result = errno;
         }
+    }
+
+    return result;
+}
+
+/*============================================================================*/
+/*  VAR_GetRequestTimeout                                                     */
+/*!
+    Set the request timeout value
+
+    The VAR_GetRequestTimeout function sets the current request timeout
+    value for the specified variable client. If the value is set to 0,
+    the client will wait indefinitely for a response from the server.
+
+    @param[in]
+        hVarServer
+            handle to the variable server
+
+    @param[out]
+        timeout_ms
+            timeout value in milliseconds to set
+
+    @retval EOK - the request timeout was successfully set
+    @retval EINVAL - invalid arguments
+
+==============================================================================*/
+int VARSERVER_SetRequestTimeout( VARSERVER_HANDLE hVarServer,
+                                 uint32_t timeout_ms )
+{
+    int result = EINVAL;
+    VarClient *pVarClient = ValidateHandle( hVarServer );
+
+    if( pVarClient != NULL )
+    {
+        pVarClient->requestTimeout_ms = timeout_ms;
+        result = EOK;
     }
 
     return result;

--- a/client/src/varserver.c
+++ b/client/src/varserver.c
@@ -696,21 +696,20 @@ int VARSERVER_Test( VARSERVER_HANDLE hVarServer )
     VarClient *pVarClient = ValidateHandle( hVarServer );
     if( pVarClient != NULL )
     {
-        for(i=0;i<100;i++)
+        for(i=0;i<1;i++)
         {
             pVarClient->requestVal = i;
             pVarClient->requestType = VARREQUEST_ECHO;
-            ClientRequest( pVarClient, SIG_CLIENT_REQUEST );
+            result = ClientRequest( pVarClient, SIG_CLIENT_REQUEST );
             if( pVarClient->debug >= LOG_DEBUG )
             {
-                printf("Client %d sent %d and received %d\n",
+                printf("Client %d sent %d and received %d, result %d\n",
                     pVarClient->clientid,
                     pVarClient->requestVal,
-                    pVarClient->responseVal);
+                    pVarClient->responseVal,
+                    result);
             }
         }
-
-        result = EOK;
     }
 
     return result;


### PR DESCRIPTION
This PR allows a client to timeout on calls to varserver so that later it can try to reconnect. The PR updates the current behaviour of just hanging.
The PR also updates the `VARSERVER_Test` call into an API to determine if the varserver connection is alive.