### PR TITLE
Introduce common dependency on Threads library

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -6,6 +6,8 @@ project(varserver
 	DESCRIPTION "Variable Server Interface Functions"
 )
 
+find_package(Threads REQUIRED)
+
 include(GNUInstallDirs)
 
 #add the library
@@ -26,7 +28,10 @@ set_target_properties( ${PROJECT_NAME} PROPERTIES
 	SOVERSION 1
 )
 
-target_link_libraries( ${PROJECT_NAME} rt )
+target_link_libraries( ${PROJECT_NAME} PUBLIC
+    ${CMAKE_THREAD_LIBS_INIT}
+    rt
+)
 
 set(VARSERVER_HEADERS
     inc/varserver/varclient.h

--- a/getvar/CMakeLists.txt
+++ b/getvar/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
 
-find_package(Threads REQUIRED)
-
 include(GNUInstallDirs)
 
 project(getvar

--- a/getvar/CMakeLists.txt
+++ b/getvar/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
+find_package(Threads REQUIRED)
+
 include(GNUInstallDirs)
 
 project(getvar
@@ -17,8 +19,6 @@ target_include_directories( ${PROJECT_NAME}
 )
 
 target_link_libraries( ${PROJECT_NAME}
-	${CMAKE_THREAD_LIBS_INIT}
-	rt
 	varserver
 )
 

--- a/mkvar/CMakeLists.txt
+++ b/mkvar/CMakeLists.txt
@@ -25,8 +25,6 @@ target_compile_options( ${PROJECT_NAME}
 )
 
 target_link_libraries( ${PROJECT_NAME}
-	${CMAKE_THREAD_LIBS_INIT}
-	rt
 	varserver
 )
 

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -32,8 +32,6 @@ target_include_directories( ${PROJECT_NAME}
 )
 
 target_link_libraries( ${PROJECT_NAME}
-    ${CMAKE_THREAD_LIBS_INIT}
-    rt
     varserver
 )
 

--- a/setvar/CMakeLists.txt
+++ b/setvar/CMakeLists.txt
@@ -17,8 +17,6 @@ target_include_directories( ${PROJECT_NAME}
 )
 
 target_link_libraries( ${PROJECT_NAME}
-	${CMAKE_THREAD_LIBS_INIT}
-	rt
 	varserver
 )
 

--- a/varalias/CMakeLists.txt
+++ b/varalias/CMakeLists.txt
@@ -17,8 +17,6 @@ target_include_directories( ${PROJECT_NAME}
 )
 
 target_link_libraries( ${PROJECT_NAME}
-	${CMAKE_THREAD_LIBS_INIT}
-	rt
 	varserver
 )
 

--- a/vartests/blobtest/CMakeLists.txt
+++ b/vartests/blobtest/CMakeLists.txt
@@ -25,8 +25,6 @@ target_compile_options( ${PROJECT_NAME}
 )
 
 target_link_libraries( ${PROJECT_NAME}
-	${CMAKE_THREAD_LIBS_INIT}
-	rt
 	varserver
 )
 


### PR DESCRIPTION
This optimises explicit dependencies added to specific tools + adds the find_package command in one place only.